### PR TITLE
[feat/#1 ] 캘린더 메인 진입 api ver1.0

### DIFF
--- a/src/config/apiConfig.ts
+++ b/src/config/apiConfig.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_APP_API_URL || "http://localhost:8080/api";

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -1,0 +1,26 @@
+import { apiClient } from "../api/client";
+import { ApiResponse } from "@/types/api";
+import { CalendarResponse, OAuthUrlResponse } from "@/types/calendar";
+
+// 캘린더 연결 시작 → 구글 OAuth URL 받기
+export async function getOAuthUrl(): Promise<OAuthUrlResponse> {
+  const res = await apiClient.get<ApiResponse<string>>("/v1/calendar/oauth-url");
+
+  if (!res.data || !res.data.data) {
+    throw new Error("OAuth URL이 비어 있습니다");
+  }
+
+  return { url: res.data.data }; 
+}
+
+// 특정 날짜 일정 조회
+export async function getCalendarByDate(date: string) {
+  const res = await apiClient.get<ApiResponse<CalendarResponse>>(`/v1/calendar/${date}`);
+  const data = res.data.data;
+  if (!data) {
+    throw new Error("날짜 응답이 비어 있습니다");
+  }
+
+  // snake_case → camelCase 변환
+  return data;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,11 @@
+/**
+ * 공통 response 타입 정의
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+  errorCode?: string;
+  path?: string;
+  timestamp: string;
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,0 +1,22 @@
+export interface Schedule {
+  id: string;
+  title: string;
+  contents: string | null;
+  useYn: string;
+  status: "PENDING" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+  // tagIds: string | null; 
+  startTime: string;
+  endTime: string;
+  relationTypes: string | null; 
+  location: string | null; 
+}
+
+export interface CalendarResponse {
+  is_connected: boolean;     
+  connect_type: string | null; // google | kakao | null
+  schedules: Schedule[];
+}
+
+export interface OAuthUrlResponse {
+  url: string; 
+}

--- a/src/utils/apiHandler.ts
+++ b/src/utils/apiHandler.ts
@@ -1,0 +1,9 @@
+import { ApiResponse } from "../types/api";
+
+export function handleApiResponse<T>(response: ApiResponse<T>): T {
+  if (!response.success) {
+    console.error(`[API ERROR] ${response.errorCode}: ${response.message}`);
+    throw new Error(response.message || "API 요청 실패");
+  }
+  return response.data as T;
+}


### PR DESCRIPTION
- 캘린더 메인 진입 api 
- /v1/calendar/oauth-url : 캘린더 연결 시작 → 구글 OAuth URL 받기
- /v1/calendar/${date} : 날짜 일정 조회
- api config : 기본 base url
- calendar response 타입 정의
- api.ts : ApiResponse 공통 타입 정의